### PR TITLE
Add feedback email scheduled for 7 days after signup

### DIFF
--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -53,6 +53,11 @@ export const useAuth: (
                 .set({ isOnboarded: true })
                 .where(eq(schema.user.id, user.id));
             });
+
+            // Schedule feedback email for 7 days after signup
+            resendService
+              .sendScheduledFeedbackEmail(user.email, { user_name: user.name })
+              .catch((err) => console.error('Failed to schedule feedback email:', err));
           },
         },
       },

--- a/apps/api/src/services/third-party/Resend.service.ts
+++ b/apps/api/src/services/third-party/Resend.service.ts
@@ -2,6 +2,7 @@ import { Context } from 'hono';
 import { Resend } from 'resend';
 import { AppContext } from '@/index';
 import { buildOrgInvitationEmail } from './emails/org-invitation';
+import { buildSignupFeedbackEmail } from './emails/signup-feedback';
 import { buildVerificationEmail } from './emails/verification';
 
 type TransactionalEmailTypes = 'verification_code' | 'org_invitation';
@@ -71,6 +72,32 @@ export class ResendService {
     if (error) {
       console.error('Failed to send email:', error);
       throw new Error(`Failed to send email: ${error.message}`);
+    }
+  }
+
+  async sendScheduledFeedbackEmail(email: string, params: { user_name: string }): Promise<void> {
+    const { subject, html } = buildSignupFeedbackEmail(params);
+    if (this.ctx.env.NODE_ENV === 'development') {
+      console.log('Skipping scheduled feedback email in development. Details:', {
+        email,
+        subject,
+        scheduledAt: 'in 7 days',
+        params,
+      });
+      return;
+    }
+
+    const { error } = await this.client.emails.send({
+      from: 'Kuba from CoderScreen <kuba@coderscreen.com>',
+      replyTo: 'team@coderscreen.com',
+      to: email,
+      subject,
+      html,
+      scheduledAt: 'in 7 days',
+    });
+
+    if (error) {
+      console.error('Failed to schedule feedback email:', error);
     }
   }
 }

--- a/apps/api/src/services/third-party/emails/signup-feedback.ts
+++ b/apps/api/src/services/third-party/emails/signup-feedback.ts
@@ -1,0 +1,34 @@
+interface SignupFeedbackEmailParams {
+  user_name: string;
+}
+
+export function buildSignupFeedbackEmail(params: SignupFeedbackEmailParams) {
+  const firstName = params.user_name.split(' ')[0];
+
+  return {
+    subject: 'Quick question about CoderScreen',
+    html: `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+  <div style="max-width:600px;margin:0 auto;padding:20px;font-size:15px;line-height:24px;color:#1a1a1a;">
+    <p>Hey ${firstName},</p>
+    <p>It's Kuba, one of the founders of CoderScreen. I noticed you signed up about a week ago and wanted to reach out personally.</p>
+    <p>I'd love to hear how things are going — whether you've had a chance to run any interviews, or if anything felt confusing or missing.</p>
+    <p>No pressure at all, but if you have a minute, just hit reply and let me know:</p>
+    <ul style="padding-left:20px;">
+      <li>What made you try CoderScreen?</li>
+      <li>Is there anything that didn't work the way you expected?</li>
+      <li>What would make it more useful for you?</li>
+    </ul>
+    <p>Even a one-liner helps a ton. We're a small team and genuinely read every response.</p>
+    <p>Thanks for giving us a shot!</p>
+    <p>Kuba</p>
+  </div>
+</body>
+</html>`,
+  };
+}


### PR DESCRIPTION
Schedule a personal feedback request email to new users 7 days after signup using Resend's built-in scheduling feature. The email comes from kuba@coderscreen.com with replies routed to team@coderscreen.com, asking for product feedback in a casual, personal tone.

Includes the feedback email template, a new scheduled send method in ResendService, and integration into the user signup flow via the auth hook.