### PR TITLE
Increase nanoid length to 32 chars

### DIFF
--- a/packages/common/src/id.ts
+++ b/packages/common/src/id.ts
@@ -35,7 +35,7 @@ export const idString = <T extends keyof Entities>(
     .transform((id: string) => id as Id<T>);
 };
 
-const idGen = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', 16);
+const idGen = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', 32);
 export const generateId = <T extends keyof Entities>(entity: T): Id<T> => {
   return `${Entities[entity]}_${idGen()}` as Id<T>;
 };


### PR DESCRIPTION
## Summary
- Increases generated ID length from 16 to 32 characters for better collision resistance

## Test plan
- [x] Existing ID validation regex (`^{prefix}_.+`) is unaffected — accepts any length after prefix
- [ ] Verify new entities get 32-char IDs in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)