### PR TITLE
Fix code editor scroll by constraining flex height

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -104,6 +104,10 @@
 }
 
 /* CODEMIRROR */
+.cm-editor {
+  height: 100%;
+}
+
 .ͼ1.cm-focused {
   outline: none;
 }

--- a/apps/web/src/components/room/editor/MultiFileCodeEditor.tsx
+++ b/apps/web/src/components/room/editor/MultiFileCodeEditor.tsx
@@ -33,7 +33,7 @@ export function MultiFileCodeEditor({ className }: MultiFileCodeEditorProps) {
       <EditorHeader handleWorkspaceReset={handleWorkspaceReset} />
 
       {/* Editor and File Explorer */}
-      <div className='flex-1 flex'>
+      <div className='flex-1 flex min-h-0'>
         <PanelGroup direction='horizontal'>
           {/* File Explorer */}
           <Panel defaultSize={20} minSize={15} maxSize={590}>

--- a/apps/web/src/components/room/editor/SingleFileCodeEditor.tsx
+++ b/apps/web/src/components/room/editor/SingleFileCodeEditor.tsx
@@ -50,11 +50,11 @@ export function SingleFileCodeEditor(_props: SingleFileCodeEditorProps) {
   }, [fileId, isElementReady, setSelectedFile]);
 
   return (
-    <div className='h-full w-full bg-white text-gray-900 relative flex flex-col'>
+    <div className='h-full w-full bg-white text-gray-900 relative flex flex-col min-h-0'>
       {/* Menu Bar */}
       <EditorHeader handleWorkspaceReset={handleWorkspaceReset} />
 
-      <div className='h-full w-full' ref={editorElementRef} />
+      <div className='flex-1 min-h-0 w-full overflow-hidden' ref={editorElementRef} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
CodeMirror's internal scroll never engaged because the editor container used `h-full` inside a flex column without `min-h-0`, letting content expand its parent instead of scrolling within it. Added `min-h-0` to the flex containers in `SingleFileCodeEditor` and `MultiFileCodeEditor`, switched the editor mount div to `flex-1 min-h-0 overflow-hidden`, and added `.cm-editor { height: 100% }` so CodeMirror fills its constrained container.

## Test plan
- [ ] Open a single-file editor with enough code to overflow the viewport and confirm scrolling works
- [ ] Open a multi-file editor and confirm both the file list and code area scroll independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)