### PR TITLE
fix: per-language editor highlighting and reliable hosted code execution

### DIFF
--- a/apps/api/src/partykit/room.do.ts
+++ b/apps/api/src/partykit/room.do.ts
@@ -381,6 +381,29 @@ export class RoomServer extends YServer<AppContext['Bindings']> {
     ]);
   }
 
+  /**
+   * Re-write the current Y.Doc workspace to the sandbox filesystem.
+   *
+   * The sandbox container is ephemeral (`SandboxDO.sleepAfter`), so it can be
+   * evicted mid-interview and lose everything under `/workspace`. `syncAllFiles`
+   * only runs once in `onLoad`, and `startObserving` only writes on subsequent
+   * edits — so a candidate who clicks "Run" after the container was reclaimed
+   * (without typing since) hits a missing file and execution fails. Calling this
+   * right before a run guarantees the entry file is present. For single-file
+   * languages (the only ones with a Run button) this is a single writeFile.
+   */
+  async ensureWorkspaceSynced(): Promise<void> {
+    if (!this.fileSyncService) {
+      const sandbox = getSandbox(this.env.SANDBOX, getSandboxId(this.name as Id<'room'>), {
+        normalizeId: true,
+      });
+      this.fileSyncService = new FileSyncService(sandbox, this.document);
+      this.fileSyncService.startObserving();
+    }
+
+    await this.fileSyncService.syncAllFiles();
+  }
+
   async handleStatusUpdate(status: RoomEntity['status']) {
     this.document.transact(() => {
       const statusText = this.document.getText('status');

--- a/apps/api/src/sandbox/languageCommands.ts
+++ b/apps/api/src/sandbox/languageCommands.ts
@@ -2,6 +2,13 @@ import type { RoomEntity } from '@coderscreen/db/room.db';
 
 interface LanguageConfig {
   extension: string;
+  // Basename of the entry file inside `/workspace`. MUST match the filename
+  // produced by the single-file template for this language (see
+  // `lib/templates/singleFileTemplates.ts`), otherwise the room runner points
+  // at a file that was never synced and execution fails. Most languages use
+  // `main<extension>`, but a few are special (bash -> script.sh, java ->
+  // Solution.java because the public class must be named Solution).
+  fileName: string;
   runCommand: (filePath: string) => string;
   compileCommand?: (filePath: string, outputPath: string) => string;
   // Function-mode questions (signature + typed test cases + harness) require a
@@ -14,60 +21,71 @@ interface LanguageConfig {
 export const LANGUAGE_CONFIG: Record<RoomEntity['language'], LanguageConfig | undefined> = {
   javascript: {
     extension: '.js',
+    fileName: 'main.js',
     runCommand: (f) => `node ${f}`,
     supportsFunctionMode: true,
   },
   typescript: {
     extension: '.ts',
+    fileName: 'main.ts',
     runCommand: (f) => `tsx ${f}`,
     supportsFunctionMode: true,
   },
   python: {
     extension: '.py',
+    fileName: 'main.py',
     runCommand: (f) => `python3 ${f}`,
     supportsFunctionMode: true,
   },
   bash: {
     extension: '.sh',
+    fileName: 'script.sh',
     runCommand: (f) => `bash ${f}`,
     supportsFunctionMode: false,
   },
   go: {
     extension: '.go',
+    fileName: 'main.go',
     runCommand: (f) => `go run ${f}`,
     supportsFunctionMode: false,
   },
   rust: {
     extension: '.rs',
+    fileName: 'main.rs',
     compileCommand: (f, o) => `rustc ${f} -o ${o}`,
     runCommand: (o) => o,
     supportsFunctionMode: false,
   },
   c: {
     extension: '.c',
+    fileName: 'main.c',
     compileCommand: (f, o) => `gcc -o ${o} ${f} -Wall -Wextra -std=c99`,
     runCommand: (o) => o,
     supportsFunctionMode: false,
   },
   'c++': {
     extension: '.cpp',
+    fileName: 'main.cpp',
     compileCommand: (f, o) => `g++ -o ${o} ${f} -Wall -Wextra -std=c++17`,
     runCommand: (o) => o,
     supportsFunctionMode: false,
   },
   java: {
     extension: '.java',
+    fileName: 'Solution.java',
     compileCommand: (f) => `javac ${f}`,
     runCommand: (f) => `java -cp /workspace ${f.replace('/workspace/', '').replace('.java', '')}`,
     supportsFunctionMode: false,
   },
   php: {
     extension: '.php',
+    fileName: 'main.php',
     runCommand: (f) => `php ${f}`,
     supportsFunctionMode: true,
   },
   ruby: {
     extension: '.rb',
+    fileName: 'main.rb',
     runCommand: (f) => `ruby ${f}`,
     supportsFunctionMode: true,
   },

--- a/apps/api/src/services/CodeRun.service.ts
+++ b/apps/api/src/services/CodeRun.service.ts
@@ -31,7 +31,11 @@ export class CodeRunService {
     const sandboxId = getSandboxId(roomId);
     const sandbox = getSandbox(this.ctx.env.SANDBOX, sandboxId, { normalizeId: true });
 
-    const filePath = `/workspace/main${config.extension}`;
+    // Re-sync the workspace from the Y.Doc in case the container was reclaimed
+    // since the last edit, otherwise the entry file may be missing.
+    await this.ensureWorkspaceSynced(roomId);
+
+    const filePath = `/workspace/${config.fileName}`;
     const outputPath = '/workspace/main_out';
 
     try {
@@ -54,6 +58,23 @@ export class CodeRunService {
     } catch (error) {
       console.error('Error streaming code:', error);
       return this.sseErrorStream(error instanceof Error ? error.message : 'Error running code');
+    }
+  }
+
+  /**
+   * Ask the room's durable object to re-write its Y.Doc workspace to the
+   * sandbox filesystem before running. The container is ephemeral and may have
+   * been reclaimed since the candidate's last edit, which would otherwise leave
+   * the entry file missing and the run failing with a "file not found" error.
+   * Best-effort: a sync failure shouldn't block the run attempt itself.
+   */
+  private async ensureWorkspaceSynced(roomId: Id<'room'>): Promise<void> {
+    try {
+      const roomName = this.ctx.env.Room.idFromName(roomId);
+      const roomStub = this.ctx.env.Room.get(roomName);
+      await roomStub.ensureWorkspaceSynced();
+    } catch (error) {
+      console.error('Failed to ensure workspace synced before run:', error);
     }
   }
 
@@ -89,7 +110,11 @@ export class CodeRunService {
     const sandboxId = getSandboxId(roomId);
     const sandbox = getSandbox(this.ctx.env.SANDBOX, sandboxId, { normalizeId: true });
 
-    const filePath = `/workspace/main${config.extension}`;
+    // Re-sync the workspace from the Y.Doc in case the container was reclaimed
+    // since the last edit, otherwise the entry file may be missing.
+    await this.ensureWorkspaceSynced(roomId);
+
+    const filePath = `/workspace/${config.fileName}`;
     const outputPath = '/workspace/main_out';
 
     try {

--- a/apps/web/src/query/realtime/editor.query.ts
+++ b/apps/web/src/query/realtime/editor.query.ts
@@ -1,6 +1,16 @@
 import { indentWithTab } from '@codemirror/commands';
+import { cpp } from '@codemirror/lang-cpp';
+import { css } from '@codemirror/lang-css';
+import { go } from '@codemirror/lang-go';
+import { html } from '@codemirror/lang-html';
+import { java } from '@codemirror/lang-java';
 import { javascript } from '@codemirror/lang-javascript';
-import { EditorState } from '@codemirror/state';
+import { json } from '@codemirror/lang-json';
+import { markdown } from '@codemirror/lang-markdown';
+import { php } from '@codemirror/lang-php';
+import { python } from '@codemirror/lang-python';
+import { rust } from '@codemirror/lang-rust';
+import { EditorState, type Extension } from '@codemirror/state';
 import { keymap } from '@codemirror/view';
 import type { RoomSchema } from '@coderscreen/api/schema/room';
 import { basicSetup, EditorView } from 'codemirror';
@@ -111,6 +121,50 @@ export const getFileTypeFromPath = (path: string): FileType => {
       return 'svelte';
     default:
       return 'unknown';
+  }
+};
+
+// Map a file's detected type to its CodeMirror language extension so each file
+// is highlighted/edited with the correct grammar. Previously every file was
+// loaded with the JS/TS extension, so Python, Go, Rust, etc. were rendered (and
+// auto-indented) as TypeScript. Types without an installed grammar (e.g. ruby,
+// bash) fall back to plain text rather than the wrong language.
+const getLanguageExtension = (fileType: FileType): Extension => {
+  switch (fileType) {
+    case 'javascript':
+    case 'jsx':
+      return javascript({ jsx: true });
+    case 'typescript':
+    case 'tsx':
+      return javascript({ jsx: true, typescript: true });
+    case 'python':
+      return python();
+    case 'java':
+      return java();
+    case 'c':
+    case 'c++':
+      return cpp();
+    case 'go':
+      return go();
+    case 'rust':
+      return rust();
+    case 'php':
+      return php();
+    case 'css':
+      return css();
+    case 'html':
+      return html();
+    case 'json':
+      return json();
+    case 'markdown':
+      return markdown();
+    // No dedicated grammar installed — HTML is the closest fit for the
+    // template-based frameworks, everything else stays plain text.
+    case 'vue':
+    case 'svelte':
+      return html();
+    default:
+      return [];
   }
 };
 
@@ -231,6 +285,11 @@ export function useMultiFileCodeEditor(elementRef: React.RefObject<HTMLDivElemen
     (fileId: string) => {
       const ytext = provider.doc.getText(getFileKey(fileId));
 
+      // Resolve the file's language from its path so it gets the right grammar.
+      const fsMap = provider.doc.getMap<FSEntry>(FS_MAP_KEY);
+      const filePath = getPathFromId(fsMap, fileId);
+      const fileType = getFileTypeFromPath(filePath);
+
       const undoManager = new Y.UndoManager(ytext);
 
       // Set up observer for text changes to increment counter
@@ -249,10 +308,7 @@ export function useMultiFileCodeEditor(elementRef: React.RefObject<HTMLDivElemen
           basicSetup,
           yCollab(ytext, null, { undoManager }),
           keymap.of([indentWithTab]),
-          javascript({
-            jsx: true,
-            typescript: true,
-          }),
+          getLanguageExtension(fileType),
         ],
       });
 


### PR DESCRIPTION
Fixes three live-interview bugs surfaced by customer feedback.

- **Highlighting:** the CodeMirror editor loaded the JS/TS grammar for every file, so Python, Go, Rust, Java, C/C++, PHP, etc. were highlighted and auto-indented as TypeScript — each file now loads the grammar matching its type (falling back to plain text where no grammar is installed).
- **Bash/Java execution:** the runner hardcoded `/workspace/main.<ext>` while the templates write `script.sh` and `Solution.java`, so those languages never ran — `LANGUAGE_CONFIG` now carries an explicit `fileName` kept in sync with the templates.
- **Mid-interview failures:** the ephemeral sandbox container could be reclaimed and lose `/workspace`, leaving Run pointing at a missing file (previously "fixed" by starting a new interview) — the runner now re-syncs the Y.Doc workspace to the sandbox via `RoomServer.ensureWorkspaceSynced()` before each run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)