### PR TITLE
fix: use org name for Stripe customer

### DIFF
--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -117,6 +117,7 @@ export const useAuth: (
             // Create customer for the organization
             await billingService.createCustomerForOrganization({
               organizationId: org.id,
+              organizationName: org.name,
               email: orgUser.email,
             });
           },

--- a/apps/api/src/services/billing/Billing.service.ts
+++ b/apps/api/src/services/billing/Billing.service.ts
@@ -27,12 +27,16 @@ export class BillingService {
     this.db = useDb(this.ctx);
   }
 
-  async createCustomerForOrganization(params: { organizationId: string; email: string }) {
-    const { organizationId, email } = params;
+  async createCustomerForOrganization(params: {
+    organizationId: string;
+    organizationName: string;
+    email: string;
+  }) {
+    const { organizationId, organizationName, email } = params;
 
     // Create Stripe customer
     const stripeCustomer = await this.stripeService.createCustomer({
-      name: `Org: ${organizationId}`,
+      name: organizationName,
       email,
       metadata: {
         organizationId,


### PR DESCRIPTION
Stripe customers were created with a random-looking `Org: <organizationId>` name. This now uses the organization name the customer set when creating their org, while still keeping `organizationId` in the customer's Stripe metadata for lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)