### PR TITLE
Refresh AI chat model options to current non-premium models

### DIFF
--- a/apps/api/src/partykit/internal/AI.service.ts
+++ b/apps/api/src/partykit/internal/AI.service.ts
@@ -85,7 +85,7 @@ Be encouraging but thorough in your evaluation. Focus on understanding their tho
      */
 
     const aiConfig = this.document.getMap(AIService.configKey);
-    const defaultModel: SupportedModels = 'openai/gpt-4.1-mini';
+    const defaultModel: SupportedModels = 'openai/gpt-5-mini';
     aiConfig.set(AIService.configKeys.model, defaultModel);
 
     const conversationId = this.document.getText(AIService.conversationIdKey);

--- a/apps/api/src/schema/ai.zod.ts
+++ b/apps/api/src/schema/ai.zod.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
-const ANTHROPIC_MODELS = ['anthropic/claude-3.7-sonnet', 'anthropic/claude-sonnet-4'] as const;
-const OPENAI_MODELS = ['openai/gpt-4.1-mini', 'openai/gpt-4o'] as const;
+const ANTHROPIC_MODELS = ['anthropic/claude-haiku-4.5', 'anthropic/claude-sonnet-4.5'] as const;
+const OPENAI_MODELS = ['openai/gpt-5-mini', 'openai/gpt-5'] as const;
 const GOOGLE_MODELS = ['google/gemini-2.5-flash', 'google/gemini-2.5-pro'] as const;
 const OTHER_MODELS = ['deepseek/deepseek-chat-v3-0324'] as const;
 

--- a/apps/web/src/components/room/ai-chat/AiChatView.tsx
+++ b/apps/web/src/components/room/ai-chat/AiChatView.tsx
@@ -36,10 +36,10 @@ const MODEL_OPTIONS: {
   value: SupportedModels;
   icon: RemixiconComponentType;
 }[] = [
-  { label: 'Claude 3.7 Sonnet', value: 'anthropic/claude-3.7-sonnet', icon: RiClaudeLine },
-  { label: 'Claude Sonnet 4', value: 'anthropic/claude-sonnet-4', icon: RiClaudeLine },
-  { label: 'GPT-4.1 Mini', value: 'openai/gpt-4.1-mini', icon: RiOpenaiFill },
-  { label: 'GPT-4o', value: 'openai/gpt-4o', icon: RiOpenaiFill },
+  { label: 'Claude Haiku 4.5', value: 'anthropic/claude-haiku-4.5', icon: RiClaudeLine },
+  { label: 'Claude Sonnet 4.5', value: 'anthropic/claude-sonnet-4.5', icon: RiClaudeLine },
+  { label: 'GPT-5 Mini', value: 'openai/gpt-5-mini', icon: RiOpenaiFill },
+  { label: 'GPT-5', value: 'openai/gpt-5', icon: RiOpenaiFill },
   { label: 'Gemini 2.5 Flash', value: 'google/gemini-2.5-flash', icon: RiGoogleLine },
   { label: 'Gemini 2.5 Pro', value: 'google/gemini-2.5-pro', icon: RiGoogleLine },
   { label: 'DeepSeek Chat V3', value: 'deepseek/deepseek-chat-v3-0324', icon: RiAiGenerate2 },

--- a/apps/web/src/query/realtime/chat.query.ts
+++ b/apps/web/src/query/realtime/chat.query.ts
@@ -39,7 +39,7 @@ export function useAIChat() {
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [config, setConfig] = useState<AIConfig>({
-    model: 'openai/gpt-4.1-mini',
+    model: 'openai/gpt-5-mini',
   });
   const [pastConversations, setPastConversations] = useState<ChatMessage[][]>([]);
   const [currentConversationId, setCurrentConversationId] = useState<string>('');


### PR DESCRIPTION
Updates the editor's AI chat model picker to current models — Claude Haiku 4.5, Claude Sonnet 4.5, GPT-5 Mini, and GPT-5 — replacing the deprecated Claude 3.7 Sonnet, Claude Sonnet 4, GPT-4.1 Mini, and GPT-4o. Gemini 2.5 Flash/Pro and DeepSeek Chat V3 are unchanged, and ultra-expensive tiers (Opus, GPT-4.5/o-pro) are deliberately excluded. Updates the `MODEL_OPTIONS` enum (source of truth), the dropdown labels, and the server- and client-side default model (now `openai/gpt-5-mini`, since the old `gpt-4.1-mini` default was dropped from the enum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)